### PR TITLE
Added set_cache_dir + refactoring to use pathlib.Path

### DIFF
--- a/trajminer/datasets/__init__.py
+++ b/trajminer/datasets/__init__.py
@@ -4,8 +4,10 @@ from .base import load_brightkite_checkins
 from .base import load_gowalla_checkins
 from .base import load_foursquare_checkins
 from .base import load_starkey_animals
+from .tools import set_cache_dir
 
 __all__ = ['load_brightkite_checkins',
            'load_gowalla_checkins',
            'load_foursquare_checkins',
-           'load_starkey_animals']
+           'load_starkey_animals',
+           'set_cache_dir']

--- a/trajminer/datasets/base.py
+++ b/trajminer/datasets/base.py
@@ -35,7 +35,7 @@ def load_brightkite_checkins(n_jobs=1, cache=True, verbose=False):
     <https://snap.stanford.edu/data/loc-brightkite.html>`__
     """
     log = lambda *x: print(*x) if verbose else True
-    csv_file = _get_csv('gowalla', 'checkins.tar.xz', cache, verbose)
+    csv_file = _get_csv('brightkite', 'checkins.tar.xz', cache, verbose)
 
     log('Loading dataset from', csv_file)
     loader = CSVTrajectoryLoader(file=csv_file, sep=',', tid_col='user',

--- a/trajminer/datasets/base.py
+++ b/trajminer/datasets/base.py
@@ -1,6 +1,5 @@
 from .tools import download_file
 from .tools import extract_tar
-from .tools import get_file_url
 from ..utils.loader import CSVTrajectoryLoader
 
 
@@ -196,6 +195,6 @@ def _get_csv(folder, file, cache, verbose=False):
     log = lambda *x: print(*x) if verbose else True
 
     log('Downloading file', file)
-    tar_file = download_file(get_file_url(folder, file), file, cache)
+    tar_file = download_file(folder, file, cache)
     log('Extracting content of', tar_file)
-    return extract_tar(tar_file)
+    return extract_tar(folder, tar_file, cache)


### PR DESCRIPTION
- We can now call `trajminer.datasets.set_cache_dir` to use a persistent cache directory (or still fall back to using a temporary folder).
- `trajminer.datasets.tools.py` was refactored to use `pathlib.Path`.
- Setting `trajminer.load_*`'s `cache=True` also caches the unzipped file¹. 

----------------------
¹ If desired, we can implement `cache` such that:
- `cache=False`: no cache, 
- `cache='compressed_only'`: cache `download_file`,
- `cache=True`: cache `download_file` **and** `extract_tar`

(or something similar, depending on the expected defaults)